### PR TITLE
Fix Rails 5 deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Start off by generating an initializer:
 
 this will create file `config/initializers/detectify.rb` in your application directory.
 
-You can configure Detectify for your application needs via initializer. After this you can access detected entity via: `env['Detectify-Entity']`.
+You can configure Detectify for your application needs via initializer. After this you can access detected entity via: `request.env['Detectify-Entity']`.
 
 ## Contributing
 

--- a/lib/detectify/railtie.rb
+++ b/lib/detectify/railtie.rb
@@ -1,7 +1,7 @@
 module Detectify
   class Railtie < Rails::Railtie
     initializer 'detectify' do |app|
-      app.config.middleware.use 'Detectify::Middleware'
+      app.config.middleware.use Detectify::Middleware
     end
   end
 end


### PR DESCRIPTION
- DEPRECATION WARNING: env is deprecated and will be removed from Rails 5.1 
- DEPRECATION WARNING: Passing strings or symbols to the middleware builder is deprecated, please change
  them to actual class references.  For example:
  
  "Detectify::Middleware" => Detectify::Middleware
